### PR TITLE
bumped version number

### DIFF
--- a/version.php
+++ b/version.php
@@ -25,12 +25,12 @@
 defined('MOODLE_INTERNAL') || die();
 
 
-$plugin->version   = 2013020700;
-$plugin->requires  = 2012062500;
+$plugin->version   = 2013042400;
+$plugin->requires  = 2013040500;
 $plugin->cron      = 0;
 $plugin->component = 'qtype_oumultiresponse';
 $plugin->maturity  = MATURITY_STABLE;
-$plugin->release   = '1.2 for Moodle 2.3+';
+$plugin->release   = '1.3 for Moodle 2.5+';
 
 $plugin->dependencies = array(
     'qtype_multichoice' => ANY_VERSION,


### PR DESCRIPTION
For each question type already updated to simplified forms I'm updating the version number and release. Using tims version updated to gapselect as reference. 
